### PR TITLE
Port customization and URI encoding

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,19 +27,20 @@ function validJson(str) {
 
 module.exports = Geocoder;
 
-function Geocoder(url) {
+function Geocoder(url, port) {
   if (!(this instanceof Geocoder)) {
     return new Geocoder();
   }
 
-  url = url || 'nominatim.openstreetmap.org';
+  url  = url  || 'nominatim.openstreetmap.org';
+  port = port || 80;
 
   // response format
   this.format = '&format=json';
 
   this.httpOptions = {
     hostname: url,
-    port: 80,
+    port: port,
     agent: false
   };
 }
@@ -84,10 +85,10 @@ Geocoder.prototype.geocode = function(addr, options, cb) {
   }
 
   // format the path
-  self.httpOptions.path = format('/search?q=%s%s%s',
+  self.httpOptions.path = encodeURI(format('/search?q=%s%s%s',
     addr.replace(/ /g, '+'),
     options,
-    self.format);
+    self.format));
 
   // exec handler
   function getGeocode(res) {


### PR DESCRIPTION
To Geocode constructor was added port:
`var geo = new OpenGeocoder('custom.nominatim.com', 8080);`

Was added URI encoding for cases like:
`Rīga, Aleksandra Čaka iela 53`